### PR TITLE
Specify eval method to call - fixes an ExecJS issue

### DIFF
--- a/lib/faster_require.rb
+++ b/lib/faster_require.rb
@@ -261,7 +261,7 @@ module FastRequire
                 if contents =~ /require_relative/ # =~ is faster apparently faster than .include?
                   load(known_loc, false) # load is slow, but overcomes a ruby core bug: http://redmine.ruby-lang.org/issues/4487
                 else
-                  eval(contents, TOPLEVEL_BINDING, known_loc) # note the 'rb' here--this means it's reading .rb files as binary, which *typically* works...maybe unnecessary though?
+                  Kernel.eval(contents, TOPLEVEL_BINDING, known_loc) # note the 'rb' here--this means it's reading .rb files as binary, which *typically* works...maybe unnecessary though?
                 end
               ensure
                 raise 'unexpected' unless IN_PROCESS.pop == known_loc


### PR DESCRIPTION
A call to eval (around line 264 in faster_require.rb) is being processed by ExecJS, instead of Kernel.

``` text
PS C:\RubyProjects\wtf > rake secret --trace
rake aborted!
wrong number of arguments (3 for 1)
C:/Ruby193/lib/ruby/gems/1.9.1/gems/execjs-1.4.0/lib/execjs/runtime.rb:38:in `eval'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/faster_require-0.9.2/lib/faster_require.rb:264:in `require_cached'
C:/Ruby193/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `block in require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:236:in `load_dependency'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/execjs-1.4.0/lib/execjs/external_runtime.rb:103:in `available?'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/execjs-1.4.0/lib/execjs/runtimes.rb:56:in `each'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/execjs-1.4.0/lib/execjs/runtimes.rb:56:in `find'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/execjs-1.4.0/lib/execjs/runtimes.rb:56:in `best_available'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/execjs-1.4.0/lib/execjs/runtimes.rb:50:in `autodetect'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/execjs-1.4.0/lib/execjs.rb:5:in `<module:ExecJS>'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/execjs-1.4.0/lib/execjs.rb:4:in `<main>'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/faster_require-0.9.2/lib/faster_require.rb:264:in `eval'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/faster_require-0.9.2/lib/faster_require.rb:264:in `require_cached'
C:/Ruby193/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `block in require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:236:in `load_dependency'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/coffee-script-2.2.0/lib/coffee_script.rb:1:in `<main>'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/faster_require-0.9.2/lib/faster_require.rb:264:in `eval'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/faster_require-0.9.2/lib/faster_require.rb:264:in `require_cached'
C:/Ruby193/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `block in require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:236:in `load_dependency'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/coffee-script-2.2.0/lib/coffee-script.rb:1:in `<main>'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/faster_require-0.9.2/lib/faster_require.rb:264:in `eval'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/faster_require-0.9.2/lib/faster_require.rb:264:in `require_cached'
C:/Ruby193/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `block in require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:236:in `load_dependency'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/coffee-rails-3.2.2/lib/coffee-rails.rb:1:in `<top (required)>'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/runtime.rb:68:in `require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/runtime.rb:68:in `block (2 levels) in require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/runtime.rb:66:in `each'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/runtime.rb:66:in `block in require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/runtime.rb:55:in `each'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/runtime.rb:55:in `require'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler.rb:119:in `require'
C:/RubyProjects/wtf/config/application.rb:9:in `<main>'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/faster_require-0.9.2/lib/faster_require.rb:264:in `eval'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/faster_require-0.9.2/lib/faster_require.rb:264:in `require_cached'
C:/Ruby193/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
C:/RubyProjects/wtf/Rakefile:5:in `<top (required)>'
C:/Ruby193/lib/ruby/1.9.1/rake/rake_module.rb:25:in `load'
C:/Ruby193/lib/ruby/1.9.1/rake/rake_module.rb:25:in `load_rakefile'
C:/Ruby193/lib/ruby/1.9.1/rake/application.rb:501:in `raw_load_rakefile'
C:/Ruby193/lib/ruby/1.9.1/rake/application.rb:82:in `block in load_rakefile'
C:/Ruby193/lib/ruby/1.9.1/rake/application.rb:133:in `standard_exception_handling'
C:/Ruby193/lib/ruby/1.9.1/rake/application.rb:81:in `load_rakefile'
C:/Ruby193/lib/ruby/1.9.1/rake/application.rb:65:in `block in run'
C:/Ruby193/lib/ruby/1.9.1/rake/application.rb:133:in `standard_exception_handling'
C:/Ruby193/lib/ruby/1.9.1/rake/application.rb:63:in `run'
C:/Ruby193/bin/rake:32:in `<main>'
```
